### PR TITLE
Adopt disposable macOS build and release pipelines

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - lastfm-lyricsheet
+    - tart-isolated

--- a/.github/actions/setup-macos-node/action.yml
+++ b/.github/actions/setup-macos-node/action.yml
@@ -1,0 +1,25 @@
+name: Set up macOS Node toolchain
+description: Verify the disposable macOS runner and install pinned Node and pnpm versions
+
+runs:
+  using: composite
+  steps:
+    - name: Ensure Homebrew tools on PATH
+      shell: bash
+      run: echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+
+    - name: Verify macOS toolchain
+      shell: bash
+      run: bash Scripts/verify-macos-ci-toolchain.sh
+
+    - name: Enable pnpm
+      shell: bash
+      run: |
+        set -euo pipefail
+        corepack enable
+        corepack prepare pnpm@11.1.2 --activate
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 24
+        cache: pnpm

--- a/.github/tart-runner-consumer.tsv
+++ b/.github/tart-runner-consumer.tsv
@@ -1,0 +1,1 @@
+tart-runner-consumer-v1	lastfm-lyricsheet	shaunchurch/lastfm-lyricsheet	lastfm-lyricsheet-ci-tart-	self-hosted,macOS,ARM64,tart-isolated,lastfm-lyricsheet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MACOS_RELEASE_ARCH: arm64
+
+jobs:
+  build:
+    # The Mac mini controller creates one disposable Tart VM for these exact
+    # labels. There is no persistent native or GitHub-hosted fallback.
+    runs-on: [self-hosted, macOS, ARM64, tart-isolated, lastfm-lyricsheet]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-macos-node
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Package unsigned macOS app
+        run: bash Scripts/package-macos-release.sh
+
+      - name: Verify packaged app
+        run: |
+          bash Scripts/verify-macos-bundle.sh \
+            --app "out/LyricSheet-darwin-${MACOS_RELEASE_ARCH}/LyricSheet.app" \
+            --version "$(node -p "require('./package.json').version")" \
+            --arch "$MACOS_RELEASE_ARCH"
+
+      - name: Verify pipeline contract
+        run: bash Scripts/tests/ci-workflow-contract.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,23 @@ jobs:
             --version "$(node -p "require('./package.json').version")" \
             --arch "$MACOS_RELEASE_ARCH"
 
+      - name: Prepare CI artifact
+        id: ci_artifact
+        run: |
+          set -euo pipefail
+          VERSION="$(node -p "require('./package.json').version")"
+          bash Scripts/prepare-macos-artifacts.sh \
+            "$VERSION" "$MACOS_RELEASE_ARCH" >> "$GITHUB_OUTPUT"
+
+      - name: Retain verified unsigned app
+        uses: actions/upload-artifact@v4
+        with:
+          name: LyricSheet-${{ github.sha }}-arm64-unsigned
+          path: |
+            ${{ steps.ci_artifact.outputs.zip_path }}
+            ${{ steps.ci_artifact.outputs.checksum_path }}
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Verify pipeline contract
         run: bash Scripts/tests/ci-workflow-contract.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,20 +15,13 @@ env:
 
 jobs:
   release:
-    runs-on: macos-15
+    # The Mac mini controller creates one disposable Tart VM for these exact
+    # labels. There is no persistent native or GitHub-hosted fallback.
+    runs-on: [self-hosted, macOS, ARM64, tart-isolated, lastfm-lyricsheet]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Enable pnpm
-        run: |
-          set -euo pipefail
-          corepack enable
-          corepack prepare pnpm@11.1.2 --activate
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
+      - uses: ./.github/actions/setup-macos-node
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -53,13 +46,14 @@ jobs:
         env:
           MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
           MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           ASC_KEY_P8: ${{ secrets.ASC_KEY_P8 }}
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         run: |
           set -euo pipefail
           missing=()
-          for name in MACOS_CERT_P12 MACOS_CERT_PASSWORD ASC_KEY_P8 ASC_KEY_ID ASC_ISSUER_ID; do
+          for name in MACOS_CERT_P12 MACOS_CERT_PASSWORD APPLE_TEAM_ID ASC_KEY_P8 ASC_KEY_ID ASC_ISSUER_ID; do
             if [ -z "${!name:-}" ]; then
               missing+=("$name")
             fi
@@ -72,26 +66,42 @@ jobs:
             echo "::error::MACOS_CERT_P12 is not valid base64. Export the .p12 and re-encode with: base64 -i DeveloperID.p12" >&2
             exit 1
           fi
+          if [[ ! "$APPLE_TEAM_ID" =~ ^[A-Z0-9]{10}$ ]]; then
+            echo "::error::APPLE_TEAM_ID must be a 10-character Apple team ID" >&2
+            exit 1
+          fi
           echo "All signing secrets present."
 
       - name: Import Developer ID certificate
         env:
           MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
           MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
-          KEYCHAIN="$RUNNER_TEMP/release.keychain-db"
+          KEYCHAIN="$RUNNER_TEMP/lyricsheet-release.keychain-db"
           KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
+          echo "MACOS_SIGN_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
           printf '%s' "$MACOS_CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security set-keychain-settings -lut 21600 "$KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security import "$RUNNER_TEMP/cert.p12" -P "$MACOS_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN"
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
-          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
-          security find-identity -v -p codesigning "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN"
           rm "$RUNNER_TEMP/cert.p12"
-          echo "MACOS_SIGN_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+
+          SIGNING_IDENTITY_HASH="$(
+            security find-identity -v -p codesigning "$KEYCHAIN" |
+              awk -v team="$APPLE_TEAM_ID" \
+                '$0 ~ /Developer ID Application:/ && $0 ~ "\\(" team "\\)" {print $2; exit}'
+          )"
+          if [ -z "$SIGNING_IDENTITY_HASH" ]; then
+            echo "::error::Imported certificate has no Developer ID Application identity for team $APPLE_TEAM_ID" >&2
+            exit 1
+          fi
+          echo "MACOS_SIGN_IDENTITY=$SIGNING_IDENTITY_HASH" >> "$GITHUB_ENV"
 
       - name: Prepare notarization key
         env:
@@ -99,44 +109,95 @@ jobs:
         run: |
           set -euo pipefail
           printf '%s' "$ASC_KEY_P8" > "$RUNNER_TEMP/asc-key.p8"
+          chmod 600 "$RUNNER_TEMP/asc-key.p8"
           echo "ASC_KEY_PATH=$RUNNER_TEMP/asc-key.p8" >> "$GITHUB_ENV"
 
       - name: Build signed and notarized macOS release
         env:
           MACOS_SIGN: "true"
-          MACOS_SIGN_IDENTITY: ${{ vars.MACOS_SIGN_IDENTITY || 'Developer ID Application' }}
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         run: bash Scripts/package-macos-release.sh
 
       - name: Verify local signed app
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          bash Scripts/verify-macos-bundle.sh \
+            --app "out/LyricSheet-darwin-${MACOS_RELEASE_ARCH}/LyricSheet.app" \
+            --version "${GITHUB_REF_NAME#v}" \
+            --arch "$MACOS_RELEASE_ARCH" \
+            --notarized \
+            --team-id "$APPLE_TEAM_ID"
+
+      - name: Prepare release artifacts
+        id: release_artifacts
         run: |
           set -euo pipefail
-          APP="out/LyricSheet-darwin-${MACOS_RELEASE_ARCH}/LyricSheet.app"
-          codesign -dv --verbose=4 "$APP" > "$RUNNER_TEMP/codesign-details.txt" 2>&1
-          grep -q '^Authority=Developer ID Application:' "$RUNNER_TEMP/codesign-details.txt"
-          grep -Eq '^(Runtime Version=|.*flags=.*runtime)' "$RUNNER_TEMP/codesign-details.txt"
-          codesign --verify --deep --strict --verbose=2 "$APP"
-          spctl -a -vv --type execute "$APP"
-          xcrun stapler validate "$APP"
+          VERSION="${GITHUB_REF_NAME#v}"
+          ZIP_PATH="out/make/zip/darwin/${MACOS_RELEASE_ARCH}/LyricSheet-darwin-${MACOS_RELEASE_ARCH}-${VERSION}.zip"
+          ZIP_NAME="$(basename "$ZIP_PATH")"
+          DIGEST="$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}')"
+          printf '%s  %s\n' "$DIGEST" "$ZIP_NAME" > "$ZIP_PATH.sha256"
+          {
+            echo "MACOS_RELEASE_ZIP=$ZIP_PATH"
+            echo "MACOS_RELEASE_CHECKSUM=$ZIP_PATH.sha256"
+          } >> "$GITHUB_ENV"
+          {
+            echo "zip_path=$ZIP_PATH"
+            echo "checksum_path=$ZIP_PATH.sha256"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Publish GitHub release
+      - name: Retain verified workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: LyricSheet-${{ github.ref_name }}-arm64
+          path: |
+            ${{ steps.release_artifacts.outputs.zip_path }}
+            ${{ steps.release_artifacts.outputs.checksum_path }}
+          if-no-files-found: error
+
+      - name: Stage draft release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
-          ZIP_PATH="out/make/zip/darwin/${MACOS_RELEASE_ARCH}/LyricSheet-darwin-${MACOS_RELEASE_ARCH}-${VERSION}.zip"
+          SOURCE_MARKER="Source commit: $GITHUB_SHA"
+          printf -v RELEASE_NOTES '%s\n\n%s' \
+            "Download LyricSheet-darwin-${MACOS_RELEASE_ARCH}-${VERSION}.zip and move LyricSheet.app to Applications." \
+            "$SOURCE_MARKER"
+          ASSETS=("$MACOS_RELEASE_ZIP" "$MACOS_RELEASE_CHECKSUM")
 
           if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" "$ZIP_PATH" --clobber
-          else
-            gh release create "$GITHUB_REF_NAME" "$ZIP_PATH" \
+            EXISTING_DRAFT="$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft)"
+            EXISTING_NOTES="$(gh release view "$GITHUB_REF_NAME" --json body --jq '.body // ""')"
+            [ "$EXISTING_DRAFT" = true ] || {
+              echo "::error::Published release $GITHUB_REF_NAME is immutable" >&2
+              exit 1
+            }
+            [[ "$EXISTING_NOTES" == *"$SOURCE_MARKER"* ]] || {
+              echo "::error::Draft release $GITHUB_REF_NAME belongs to another source commit" >&2
+              exit 1
+            }
+            gh release upload "$GITHUB_REF_NAME" "${ASSETS[@]}" --clobber
+            gh release edit "$GITHUB_REF_NAME" \
+              --draft \
               --title "LyricSheet $VERSION" \
-              --generate-notes
+              --notes "$RELEASE_NOTES"
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              "${ASSETS[@]}" \
+              --draft \
+              --verify-tag \
+              --title "LyricSheet $VERSION" \
+              --notes "$RELEASE_NOTES"
           fi
 
-      - name: Verify published release
+      - name: Verify staged release
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
@@ -144,4 +205,22 @@ jobs:
             --version "$VERSION" \
             --release-repo "$GITHUB_REPOSITORY" \
             --tag "$GITHUB_REF_NAME" \
-            --arch "$MACOS_RELEASE_ARCH"
+            --arch "$MACOS_RELEASE_ARCH" \
+            --team-id "$APPLE_TEAM_ID"
+
+      - name: Publish verified release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false
+
+      - name: Clean up signing material
+        if: always()
+        run: |
+          security list-keychains -d user -s login.keychain-db 2>/dev/null || true
+          if [ -n "${MACOS_SIGN_KEYCHAIN:-}" ]; then
+            security delete-keychain "$MACOS_SIGN_KEYCHAIN" 2>/dev/null || true
+          fi
+          rm -f \
+            "$RUNNER_TEMP/cert.p12" \
+            "$RUNNER_TEMP/asc-key.p8" \
+            "$RUNNER_TEMP/notarize.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,18 +135,8 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
-          ZIP_PATH="out/make/zip/darwin/${MACOS_RELEASE_ARCH}/LyricSheet-darwin-${MACOS_RELEASE_ARCH}-${VERSION}.zip"
-          ZIP_NAME="$(basename "$ZIP_PATH")"
-          DIGEST="$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}')"
-          printf '%s  %s\n' "$DIGEST" "$ZIP_NAME" > "$ZIP_PATH.sha256"
-          {
-            echo "MACOS_RELEASE_ZIP=$ZIP_PATH"
-            echo "MACOS_RELEASE_CHECKSUM=$ZIP_PATH.sha256"
-          } >> "$GITHUB_ENV"
-          {
-            echo "zip_path=$ZIP_PATH"
-            echo "checksum_path=$ZIP_PATH.sha256"
-          } >> "$GITHUB_OUTPUT"
+          bash Scripts/prepare-macos-artifacts.sh \
+            "$VERSION" "$MACOS_RELEASE_ARCH" >> "$GITHUB_OUTPUT"
 
       - name: Retain verified workflow artifact
         uses: actions/upload-artifact@v4
@@ -160,6 +150,8 @@ jobs:
       - name: Stage draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          MACOS_RELEASE_ZIP: ${{ steps.release_artifacts.outputs.zip_path }}
+          MACOS_RELEASE_CHECKSUM: ${{ steps.release_artifacts.outputs.checksum_path }}
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"

--- a/Scripts/prepare-macos-artifacts.sh
+++ b/Scripts/prepare-macos-artifacts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+if [ "$#" -ne 2 ]; then
+  fail "usage: $0 VERSION ARCH"
+fi
+
+version="$1"
+arch="$2"
+
+case "$version" in
+  *[!0-9A-Za-z.+-]*|'') fail "invalid version '$version'" ;;
+esac
+
+case "$arch" in
+  arm64|x64|universal) ;;
+  *) fail "unsupported architecture '$arch'" ;;
+esac
+
+zip_path="out/make/zip/darwin/${arch}/LyricSheet-darwin-${arch}-${version}.zip"
+zip_name="$(basename "$zip_path")"
+
+[ -f "$zip_path" ] || fail "packaged ZIP not found at $zip_path"
+
+digest="$(shasum -a 256 "$zip_path" | awk '{print $1}')"
+printf '%s  %s\n' "$digest" "$zip_name" > "$zip_path.sha256"
+printf 'zip_path=%s\nchecksum_path=%s\n' "$zip_path" "$zip_path.sha256"

--- a/Scripts/tests/ci-workflow-contract.sh
+++ b/Scripts/tests/ci-workflow-contract.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ci_workflow="$root/.github/workflows/ci.yml"
+release_workflow="$root/.github/workflows/release.yml"
+consumer="$root/.github/tart-runner-consumer.tsv"
+actionlint_config="$root/.github/actionlint.yaml"
+toolchain_action="$root/.github/actions/setup-macos-node/action.yml"
+expected_consumer=$'tart-runner-consumer-v1\tlastfm-lyricsheet\tshaunchurch/lastfm-lyricsheet\tlastfm-lyricsheet-ci-tart-\tself-hosted,macOS,ARM64,tart-isolated,lastfm-lyricsheet'
+runner_labels='runs-on: [self-hosted, macOS, ARM64, tart-isolated, lastfm-lyricsheet]'
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_literal() {
+  local file="$1"
+  local value="$2"
+  grep -Fq -- "$value" "$file" || fail "$file is missing: $value"
+}
+
+[ -f "$ci_workflow" ] || fail "CI workflow is missing"
+[ -f "$release_workflow" ] || fail "release workflow is missing"
+[ -f "$consumer" ] || fail "Tart consumer declaration is missing"
+[ -f "$actionlint_config" ] || fail "actionlint configuration is missing"
+[ -f "$toolchain_action" ] || fail "shared toolchain action is missing"
+
+[ "$(cat "$consumer")" = "$expected_consumer" ] ||
+  fail "Tart consumer declaration does not match the controller contract"
+[ "$(wc -l < "$consumer" | tr -d ' ')" = 1 ] ||
+  fail "Tart consumer declaration must be one newline-terminated row"
+
+for workflow in "$ci_workflow" "$release_workflow"; do
+  require_literal "$workflow" "$runner_labels"
+  require_literal "$workflow" 'uses: ./.github/actions/setup-macos-node'
+done
+
+for value in \
+  'permissions:' \
+  'contents: read' \
+  'pnpm install --frozen-lockfile' \
+  'pnpm run typecheck' \
+  'pnpm test' \
+  'bash Scripts/package-macos-release.sh' \
+  'bash Scripts/verify-macos-bundle.sh'; do
+  require_literal "$ci_workflow" "$value"
+done
+
+for value in \
+  'bash Scripts/verify-macos-ci-toolchain.sh' \
+  'corepack prepare pnpm@11.1.2 --activate' \
+  'actions/setup-node@v4' \
+  'node-version: 24' \
+  'cache: pnpm'; do
+  require_literal "$toolchain_action" "$value"
+done
+
+for value in \
+  'APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}' \
+  'MACOS_SIGN_IDENTITY=$SIGNING_IDENTITY_HASH' \
+  'actions/upload-artifact@v4' \
+  'shasum -a 256' \
+  'Stage draft release' \
+  'Source commit: $GITHUB_SHA' \
+  'Published release $GITHUB_REF_NAME is immutable' \
+  'Verify staged release' \
+  'Publish verified release' \
+  'Clean up signing material' \
+  'if: always()' \
+  'security delete-keychain'; do
+  require_literal "$release_workflow" "$value"
+done
+
+require_literal "$actionlint_config" 'lastfm-lyricsheet'
+require_literal "$actionlint_config" 'tart-isolated'
+
+if grep -REq 'runs-on: (macos-|ubuntu-|windows-)' "$root/.github/workflows"; then
+  fail "a workflow still uses a GitHub-hosted runner"
+fi
+
+echo "CI and release workflow contract passed"

--- a/Scripts/tests/ci-workflow-contract.sh
+++ b/Scripts/tests/ci-workflow-contract.sh
@@ -45,7 +45,11 @@ for value in \
   'pnpm run typecheck' \
   'pnpm test' \
   'bash Scripts/package-macos-release.sh' \
-  'bash Scripts/verify-macos-bundle.sh'; do
+  'bash Scripts/verify-macos-bundle.sh' \
+  'bash Scripts/prepare-macos-artifacts.sh' \
+  'actions/upload-artifact@v4' \
+  'LyricSheet-${{ github.sha }}-arm64-unsigned' \
+  'if-no-files-found: error'; do
   require_literal "$ci_workflow" "$value"
 done
 
@@ -61,8 +65,8 @@ done
 for value in \
   'APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}' \
   'MACOS_SIGN_IDENTITY=$SIGNING_IDENTITY_HASH' \
+  'bash Scripts/prepare-macos-artifacts.sh' \
   'actions/upload-artifact@v4' \
-  'shasum -a 256' \
   'Stage draft release' \
   'Source commit: $GITHUB_SHA' \
   'Published release $GITHUB_REF_NAME is immutable' \

--- a/Scripts/verify-macos-bundle.sh
+++ b/Scripts/verify-macos-bundle.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: verify-macos-bundle.sh --app <path> --version <x.y.z> --arch <arm64|x64|universal> [--signed] [--notarized] [--team-id <id>]
+
+Checks a packaged LyricSheet app's identity, version, architecture, and payload.
+Signed builds can also be checked for Developer ID, hardened runtime, and a
+stapled notarization ticket.
+USAGE
+}
+
+app_path=""
+version=""
+arch=""
+signed=false
+notarized=false
+team_id=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --app)
+      app_path="${2:-}"
+      shift 2
+      ;;
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --arch)
+      arch="${2:-}"
+      shift 2
+      ;;
+    --signed)
+      signed=true
+      shift
+      ;;
+    --notarized)
+      signed=true
+      notarized=true
+      shift
+      ;;
+    --team-id)
+      team_id="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "$app_path" ] || fail "--app is required"
+[ -n "$version" ] || fail "--version is required"
+
+case "$arch" in
+  arm64|x64|universal) ;;
+  *) fail "--arch must be arm64, x64, or universal" ;;
+esac
+
+info_plist="$app_path/Contents/Info.plist"
+executable="$app_path/Contents/MacOS/LyricSheet"
+app_asar="$app_path/Contents/Resources/app.asar"
+
+[ -d "$app_path" ] || fail "app not found at $app_path"
+[ -f "$info_plist" ] || fail "app is missing Contents/Info.plist"
+[ -x "$executable" ] || fail "app is missing its LyricSheet executable"
+[ -f "$app_asar" ] || fail "app is missing Contents/Resources/app.asar"
+
+plist_value() {
+  /usr/libexec/PlistBuddy -c "Print :$2" "$1"
+}
+
+actual_version="$(plist_value "$info_plist" CFBundleShortVersionString)"
+actual_bundle_id="$(plist_value "$info_plist" CFBundleIdentifier)"
+actual_executable="$(plist_value "$info_plist" CFBundleExecutable)"
+
+[ "$actual_version" = "$version" ] ||
+  fail "app version is $actual_version, expected $version"
+[ "$actual_bundle_id" = "com.lyricsheet.app" ] ||
+  fail "app bundle id is $actual_bundle_id"
+[ "$actual_executable" = "LyricSheet" ] ||
+  fail "app executable is $actual_executable"
+
+binary_arches="$(lipo -archs "$executable")"
+case "$arch" in
+  arm64)
+    [ "$binary_arches" = arm64 ] || fail "app architecture is $binary_arches, expected arm64"
+    ;;
+  x64)
+    [ "$binary_arches" = x86_64 ] || fail "app architecture is $binary_arches, expected x86_64"
+    ;;
+  universal)
+    [[ " $binary_arches " == *" arm64 "* && " $binary_arches " == *" x86_64 "* ]] ||
+      fail "universal app architectures are $binary_arches"
+    ;;
+esac
+
+if [ "$signed" = true ]; then
+  details="$(mktemp "${TMPDIR:-/tmp}/lyricsheet-codesign.XXXXXX")"
+  trap 'rm -f "$details"' EXIT
+  codesign -dv --verbose=4 "$app_path" > "$details" 2>&1
+  grep -q '^Authority=Developer ID Application:' "$details" ||
+    fail "app is not signed with a Developer ID Application certificate"
+  grep -Eq '^(Runtime Version=|.*flags=.*runtime)' "$details" ||
+    fail "app does not have hardened runtime enabled"
+  grep -q '^TeamIdentifier=' "$details" || fail "app has no signing team identifier"
+  if [ -n "$team_id" ]; then
+    grep -Fq "TeamIdentifier=$team_id" "$details" ||
+      fail "app is not signed by team $team_id"
+  fi
+  codesign --verify --deep --strict --verbose=2 "$app_path"
+fi
+
+if [ "$notarized" = true ]; then
+  spctl -a -vv --type execute "$app_path"
+  xcrun stapler validate "$app_path"
+fi
+
+echo "Verified LyricSheet $version ($arch) at $app_path"

--- a/Scripts/verify-macos-ci-toolchain.sh
+++ b/Scripts/verify-macos-ci-toolchain.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+[ "$(uname -m)" = arm64 ] || fail "macOS pipelines require an arm64 runner"
+
+xcode_version="$(xcodebuild -version | awk '/^Xcode / {print $2; exit}')"
+sdk_version="$(xcrun --sdk macosx --show-sdk-version)"
+
+[[ "$xcode_version" == 26.* ]] ||
+  fail "macOS pipelines require Xcode 26, got ${xcode_version:-unknown}"
+[[ "$sdk_version" == 26.* ]] ||
+  fail "macOS pipelines require the macOS 26 SDK, got ${sdk_version:-unknown}"
+
+echo "Verified arm64, Xcode $xcode_version, and macOS SDK $sdk_version"

--- a/Scripts/verify-published-release.sh
+++ b/Scripts/verify-published-release.sh
@@ -8,7 +8,7 @@ fail() {
 
 usage() {
   cat <<'USAGE'
-Usage: verify-published-release.sh --version <x.y.z> --release-repo <owner/repo> --tag <vX.Y.Z> [--arch arm64|x64|universal]
+Usage: verify-published-release.sh --version <x.y.z> --release-repo <owner/repo> --tag <vX.Y.Z> --team-id <id> [--arch arm64|x64|universal]
 
 Downloads the public GitHub release zip and verifies that Gatekeeper can accept
 the shipped macOS app.
@@ -19,6 +19,7 @@ version=""
 release_repo=""
 tag=""
 arch="arm64"
+team_id=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -38,6 +39,10 @@ while [ "$#" -gt 0 ]; do
       arch="${2:-}"
       shift 2
       ;;
+    --team-id)
+      team_id="${2:-}"
+      shift 2
+      ;;
     --help|-h)
       usage
       exit 0
@@ -51,6 +56,7 @@ done
 [ -n "$version" ] || fail "--version is required"
 [ -n "$release_repo" ] || fail "--release-repo is required"
 [ -n "$tag" ] || fail "--tag is required"
+[ -n "$team_id" ] || fail "--team-id is required"
 
 case "$arch" in
   arm64|x64|universal) ;;
@@ -65,9 +71,11 @@ trap 'rm -rf "$workdir"' EXIT
 asset_name="LyricSheet-darwin-${arch}-${version}.zip"
 zip_url="https://github.com/${release_repo}/releases/download/${tag}/${asset_name}"
 zip_path="$workdir/$asset_name"
+checksum_name="$asset_name.sha256"
+checksum_url="$zip_url.sha256"
+checksum_path="$workdir/$checksum_name"
 unzipped_dir="$workdir/unzipped"
 app_path="$unzipped_dir/LyricSheet.app"
-app_info_plist="$app_path/Contents/Info.plist"
 
 curl_retry() {
   local url="$1"
@@ -87,33 +95,28 @@ curl_retry() {
   done
 }
 
-plist_value() {
-  /usr/libexec/PlistBuddy -c "Print :$2" "$1"
-}
-
-echo "Downloading published release asset: $zip_url"
-curl_retry "$zip_url" "$zip_path" || fail "could not download published release asset"
-shasum -a 256 "$zip_path"
+if [ -n "${GH_TOKEN:-}" ]; then
+  gh release download "$tag" \
+    --repo "$release_repo" \
+    --dir "$workdir" \
+    --pattern "$asset_name" \
+    --pattern "$checksum_name" || fail "could not download staged release assets"
+else
+  echo "Downloading published release asset: $zip_url"
+  curl_retry "$zip_url" "$zip_path" || fail "could not download published release asset"
+  curl_retry "$checksum_url" "$checksum_path" || fail "could not download published checksum"
+fi
+(cd "$workdir" && shasum -a 256 -c "$checksum_name") || fail "published checksum does not match"
 
 mkdir -p "$unzipped_dir"
 ditto -x -k "$zip_path" "$unzipped_dir"
 [ -d "$app_path" ] || fail "release zip did not contain LyricSheet.app"
-[ -f "$app_info_plist" ] || fail "release app is missing Contents/Info.plist"
 
-actual_version="$(plist_value "$app_info_plist" CFBundleShortVersionString)"
-actual_bundle_id="$(plist_value "$app_info_plist" CFBundleIdentifier)"
+"$(dirname "$0")/verify-macos-bundle.sh" \
+  --app "$app_path" \
+  --version "$version" \
+  --arch "$arch" \
+  --notarized \
+  --team-id "$team_id"
 
-[ "$actual_version" = "$version" ] || fail "published app version is $actual_version, expected $version"
-[ "$actual_bundle_id" = "com.lyricsheet.app" ] || fail "published app bundle id is $actual_bundle_id"
-
-codesign_details="$workdir/codesign-details.txt"
-codesign -dv --verbose=4 "$app_path" > "$codesign_details" 2>&1
-grep -q '^Authority=Developer ID Application:' "$codesign_details" || fail "published app is not signed with a Developer ID Application certificate"
-grep -Eq '^(Runtime Version=|.*flags=.*runtime)' "$codesign_details" || fail "published app does not have hardened runtime enabled"
-grep -q '^TeamIdentifier=' "$codesign_details" || fail "published app has no signing team identifier"
-
-codesign --verify --deep --strict --verbose=2 "$app_path"
-spctl -a -vv --type execute "$app_path"
-xcrun stapler validate "$app_path"
-
-echo "Published release $tag is signed, notarized, stapled, and Gatekeeper-accepted"
+echo "Release $tag is signed, notarized, stapled, and Gatekeeper-accepted"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -12,8 +12,8 @@ damaged or corrupt after download.
 3. Push a matching tag:
 
    ```sh
-   git tag v0.2.1
-   git push origin v0.2.1
+   git tag v0.2.2
+   git push origin v0.2.2
    ```
 
 4. Watch the **Release** GitHub Actions workflow.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -17,21 +17,30 @@ damaged or corrupt after download.
    ```
 
 4. Watch the **Release** GitHub Actions workflow.
-5. Confirm the final **Verify published release** step passed.
+5. Confirm **Verify staged release** passed and **Publish verified release**
+   completed.
 
 ## What The Workflow Does
 
 1. Verifies the tag matches `package.json`.
-2. Installs dependencies from `pnpm-lock.yaml`.
-3. Runs typecheck and tests.
-4. Imports the Developer ID Application certificate into an ephemeral keychain.
-5. Builds LyricSheet with Electron Forge, Developer ID signing, hardened runtime,
+2. Runs in a disposable Tart VM on the shared Mac mini and verifies the pinned
+   arm64/Xcode 26 toolchain.
+3. Installs dependencies from `pnpm-lock.yaml`.
+4. Runs typecheck and tests.
+5. Imports the expected Apple team's Developer ID Application certificate into
+   an ephemeral keychain.
+6. Builds LyricSheet with Electron Forge, Developer ID signing, hardened runtime,
    notarization, and stapling enabled.
-6. Packages `LyricSheet.app` with `ditto --keepParent`.
-7. Publishes or replaces the GitHub release ZIP for the tag.
-8. Re-downloads the public ZIP and verifies the shipped app version, bundle ID,
-   Developer ID signature, hardened runtime, code-signing integrity, Gatekeeper
-   acceptance, and stapled notarization ticket.
+7. Packages `LyricSheet.app` with `ditto --keepParent`, writes a SHA-256 file,
+   and retains both as a workflow artifact.
+8. Stages a draft GitHub release tied to the source commit. Published releases
+   are immutable; only a draft owned by the same commit may be replaced.
+9. Downloads the staged artifacts and verifies the checksum, shipped app
+   version, bundle ID, architecture, expected signing team, hardened runtime,
+   code-signing integrity, Gatekeeper acceptance, and notarization ticket.
+10. Publishes the draft only after verification passes.
+11. Removes the release keychain and API key material on every exit path. The
+    Tart controller then erases the VM.
 
 Sparkle updates are intentionally out of scope for now.
 
@@ -43,15 +52,21 @@ Set these in GitHub repository secrets:
 | --- | --- |
 | `MACOS_CERT_P12` | Developer ID Application certificate, `.p12` export, base64-encoded |
 | `MACOS_CERT_PASSWORD` | Password protecting the `.p12` |
+| `APPLE_TEAM_ID` | 10-character Apple Developer team ID expected in the certificate and shipped signature |
 | `ASC_KEY_ID` | App Store Connect API key ID for notarization |
 | `ASC_ISSUER_ID` | App Store Connect issuer ID |
 | `ASC_KEY_P8` | Contents of the App Store Connect API `.p8` key |
 
-Optional repository variable:
+## Continuous Integration
 
-| Variable | Default | Purpose |
-| --- | --- | --- |
-| `MACOS_SIGN_IDENTITY` | `Developer ID Application` | Exact signing identity if the keychain contains more than one Developer ID Application certificate |
+Pull requests and pushes to `master` run `.github/workflows/ci.yml`. CI uses the
+same disposable Tart runner and pinned Node/pnpm toolchain as Release, but has
+read-only permissions and no signing secrets. It typechecks, tests, packages an
+unsigned arm64 app, and verifies the bundle without launching it.
+
+Both workflows request the exact labels `self-hosted, macOS, ARM64,
+tart-isolated, lastfm-lyricsheet`. The shared controller must pin the matching
+`.github/tart-runner-consumer.tsv` declaration before jobs can be admitted.
 
 ## Local Notes
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -62,7 +62,10 @@ Set these in GitHub repository secrets:
 Pull requests and pushes to `master` run `.github/workflows/ci.yml`. CI uses the
 same disposable Tart runner and pinned Node/pnpm toolchain as Release, but has
 read-only permissions and no signing secrets. It typechecks, tests, packages an
-unsigned arm64 app, and verifies the bundle without launching it.
+unsigned arm64 app, and verifies the bundle without launching it. After
+verification, each run retains the ZIP and its SHA-256 checksum for 14 days as
+the `LyricSheet-<commit>-arm64-unsigned` workflow artifact. This is a test build,
+not the signed and notarized public release.
 
 Both workflows request the exact labels `self-hosted, macOS, ARM64,
 tart-isolated, lastfm-lyricsheet`. The shared controller must pin the matching

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastfm-lyricsheet",
   "productName": "LyricSheet",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A tiny always-on desktop lyric sheet for your current Last.fm track.",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
## What changed

- run PR, master, and tag builds in repo-scoped disposable Tart VMs
- add unsigned CI packaging and bundle verification
- harden Developer ID signing, notarization, checksums, and cleanup
- stage and verify draft releases before publishing; published releases are immutable
- bump LyricSheet to 0.2.2

## Why

Move LyricSheet onto the shared macOS build/release process used by the other
apps, while keeping signing secrets inside the disposable release job.

## Checks

- `pnpm run typecheck`
- `pnpm test` (6 passing)
- `pnpm run release:mac`
- 0.2.2 arm64 bundle verification
- workflow contract, actionlint, and shellcheck

## Dependency

The shared Tart controller must merge and install the matching
`lastfm-lyricsheet` consumer contract before this PR's CI job can be admitted.
