### PR TITLE
Publish signed and notarized macOS DMG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           name: LyricSheet-${{ github.sha }}-arm64-unsigned
           path: |
             ${{ steps.ci_artifact.outputs.zip_path }}
-            ${{ steps.ci_artifact.outputs.checksum_path }}
+            ${{ steps.ci_artifact.outputs.zip_checksum_path }}
           if-no-files-found: error
           retention-days: 14
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,13 +130,30 @@ jobs:
             --notarized \
             --team-id "$APPLE_TEAM_ID"
 
+      - name: Build signed and notarized DMG
+        env:
+          MACOS_SIGN: "true"
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: bash Scripts/package-macos-dmg.sh
+
+      - name: Verify local signed DMG
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          bash Scripts/verify-macos-dmg.sh \
+            --dmg "out/make/dmg/darwin/${MACOS_RELEASE_ARCH}/LyricSheet-darwin-${MACOS_RELEASE_ARCH}-${GITHUB_REF_NAME#v}.dmg" \
+            --version "${GITHUB_REF_NAME#v}" \
+            --arch "$MACOS_RELEASE_ARCH" \
+            --team-id "$APPLE_TEAM_ID"
+
       - name: Prepare release artifacts
         id: release_artifacts
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
           bash Scripts/prepare-macos-artifacts.sh \
-            "$VERSION" "$MACOS_RELEASE_ARCH" >> "$GITHUB_OUTPUT"
+            "$VERSION" "$MACOS_RELEASE_ARCH" --with-dmg >> "$GITHUB_OUTPUT"
 
       - name: Retain verified workflow artifact
         uses: actions/upload-artifact@v4
@@ -144,22 +161,31 @@ jobs:
           name: LyricSheet-${{ github.ref_name }}-arm64
           path: |
             ${{ steps.release_artifacts.outputs.zip_path }}
-            ${{ steps.release_artifacts.outputs.checksum_path }}
+            ${{ steps.release_artifacts.outputs.zip_checksum_path }}
+            ${{ steps.release_artifacts.outputs.dmg_path }}
+            ${{ steps.release_artifacts.outputs.dmg_checksum_path }}
           if-no-files-found: error
 
       - name: Stage draft release
         env:
           GH_TOKEN: ${{ github.token }}
           MACOS_RELEASE_ZIP: ${{ steps.release_artifacts.outputs.zip_path }}
-          MACOS_RELEASE_CHECKSUM: ${{ steps.release_artifacts.outputs.checksum_path }}
+          MACOS_RELEASE_ZIP_CHECKSUM: ${{ steps.release_artifacts.outputs.zip_checksum_path }}
+          MACOS_RELEASE_DMG: ${{ steps.release_artifacts.outputs.dmg_path }}
+          MACOS_RELEASE_DMG_CHECKSUM: ${{ steps.release_artifacts.outputs.dmg_checksum_path }}
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
           SOURCE_MARKER="Source commit: $GITHUB_SHA"
           printf -v RELEASE_NOTES '%s\n\n%s' \
-            "Download LyricSheet-darwin-${MACOS_RELEASE_ARCH}-${VERSION}.zip and move LyricSheet.app to Applications." \
+            "Download the DMG for normal installation. The ZIP is retained for update tooling and manual installation." \
             "$SOURCE_MARKER"
-          ASSETS=("$MACOS_RELEASE_ZIP" "$MACOS_RELEASE_CHECKSUM")
+          ASSETS=(
+            "$MACOS_RELEASE_ZIP"
+            "$MACOS_RELEASE_ZIP_CHECKSUM"
+            "$MACOS_RELEASE_DMG"
+            "$MACOS_RELEASE_DMG_CHECKSUM"
+          )
 
           if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
             EXISTING_DRAFT="$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft)"
@@ -215,4 +241,6 @@ jobs:
           rm -f \
             "$RUNNER_TEMP/cert.p12" \
             "$RUNNER_TEMP/asc-key.p8" \
-            "$RUNNER_TEMP/notarize.zip"
+            "$RUNNER_TEMP/notarize.zip" \
+            "$RUNNER_TEMP/lyricsheet-dmg-notary-submit.plist" \
+            "$RUNNER_TEMP/lyricsheet-dmg-notary-log.json"

--- a/Scripts/package-macos-dmg.sh
+++ b/Scripts/package-macos-dmg.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_env() {
+  local name="$1"
+  [ -n "${!name:-}" ] || fail "MACOS_SIGN=true requires $name"
+}
+
+app_name="LyricSheet"
+version="$(node -p "require('./package.json').version")"
+arch="${MACOS_RELEASE_ARCH:-arm64}"
+
+case "$version" in
+  *[!0-9A-Za-z.+-]*|'') fail "invalid package version '$version'" ;;
+esac
+
+case "$arch" in
+  arm64|x64|universal) ;;
+  *) fail "unsupported MACOS_RELEASE_ARCH '$arch'" ;;
+esac
+
+app_path="out/${app_name}-darwin-${arch}/${app_name}.app"
+maker_dmg_path="out/make/${app_name}-${version}-${arch}.dmg"
+dmg_dir="out/make/dmg/darwin/${arch}"
+dmg_path="${dmg_dir}/${app_name}-darwin-${arch}-${version}.dmg"
+
+[ -d "$app_path" ] || fail "packaged app not found at $app_path"
+
+cache_env=(
+  XDG_CACHE_HOME=.cache
+  ELECTRON_CACHE=.cache/electron
+  electron_config_cache=.cache/electron
+  npm_config_devdir=.cache/node-gyp
+)
+
+mkdir -p "$dmg_dir"
+rm -f "$maker_dmg_path" "$dmg_path"
+env "${cache_env[@]}" pnpm exec electron-forge make \
+  --targets=@electron-forge/maker-dmg \
+  --skip-package \
+  --platform=darwin \
+  --arch="$arch"
+
+[ -f "$maker_dmg_path" ] ||
+  fail "Electron Forge DMG not found at $maker_dmg_path"
+mv "$maker_dmg_path" "$dmg_path"
+
+if [ "${MACOS_SIGN:-false}" = true ]; then
+  for name in \
+    MACOS_SIGN_IDENTITY \
+    MACOS_SIGN_KEYCHAIN \
+    ASC_KEY_PATH \
+    ASC_KEY_ID \
+    ASC_ISSUER_ID; do
+    require_env "$name"
+  done
+
+  codesign \
+    --sign "$MACOS_SIGN_IDENTITY" \
+    --keychain "$MACOS_SIGN_KEYCHAIN" \
+    --identifier com.lyricsheet.app.dmg \
+    --timestamp \
+    "$dmg_path"
+  codesign --verify --strict --verbose=2 "$dmg_path"
+
+  base_temp="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+  base_temp="${base_temp%/}"
+  submit_plist="$base_temp/lyricsheet-dmg-notary-submit.plist"
+  notary_log="$base_temp/lyricsheet-dmg-notary-log.json"
+  notary_auth=(
+    --key "$ASC_KEY_PATH"
+    --key-id "$ASC_KEY_ID"
+    --issuer "$ASC_ISSUER_ID"
+  )
+  rm -f "$submit_plist" "$notary_log"
+
+  if ! xcrun notarytool submit "$dmg_path" \
+    "${notary_auth[@]}" \
+    --wait \
+    --timeout 1h \
+    --output-format plist > "$submit_plist"; then
+    cat "$submit_plist" >&2
+    fail "DMG notarization submission failed"
+  fi
+
+  submission_status="$(
+    /usr/libexec/PlistBuddy -c 'Print :status' "$submit_plist"
+  )"
+  submission_id="$(
+    /usr/libexec/PlistBuddy -c 'Print :id' "$submit_plist"
+  )"
+  [ -n "$submission_id" ] || fail "DMG notarization returned no submission ID"
+
+  xcrun notarytool log "$submission_id" "$notary_log" "${notary_auth[@]}"
+  if [ "$submission_status" != Accepted ]; then
+    cat "$notary_log" >&2
+    fail "DMG notarization status is '$submission_status'"
+  fi
+  if grep -Eq '"severity"[[:space:]]*:[[:space:]]*"(warning|error)"' "$notary_log"; then
+    cat "$notary_log" >&2
+    fail "DMG notarization log contains warnings or errors"
+  fi
+
+  xcrun stapler staple "$dmg_path"
+  xcrun stapler validate "$dmg_path"
+  spctl -a -t open -vvv --context context:primary-signature "$dmg_path"
+fi
+
+echo "$dmg_path"

--- a/Scripts/prepare-macos-artifacts.sh
+++ b/Scripts/prepare-macos-artifacts.sh
@@ -6,12 +6,17 @@ fail() {
   exit 1
 }
 
-if [ "$#" -ne 2 ]; then
-  fail "usage: $0 VERSION ARCH"
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+  fail "usage: $0 VERSION ARCH [--with-dmg]"
 fi
 
 version="$1"
 arch="$2"
+with_dmg=false
+if [ "$#" -eq 3 ]; then
+  [ "$3" = --with-dmg ] || fail "unknown argument '$3'"
+  with_dmg=true
+fi
 
 case "$version" in
   *[!0-9A-Za-z.+-]*|'') fail "invalid version '$version'" ;;
@@ -24,9 +29,23 @@ esac
 
 zip_path="out/make/zip/darwin/${arch}/LyricSheet-darwin-${arch}-${version}.zip"
 zip_name="$(basename "$zip_path")"
+zip_checksum_path="$zip_path.sha256"
 
 [ -f "$zip_path" ] || fail "packaged ZIP not found at $zip_path"
 
 digest="$(shasum -a 256 "$zip_path" | awk '{print $1}')"
-printf '%s  %s\n' "$digest" "$zip_name" > "$zip_path.sha256"
-printf 'zip_path=%s\nchecksum_path=%s\n' "$zip_path" "$zip_path.sha256"
+printf '%s  %s\n' "$digest" "$zip_name" > "$zip_checksum_path"
+printf 'zip_path=%s\nzip_checksum_path=%s\n' \
+  "$zip_path" "$zip_checksum_path"
+
+if [ "$with_dmg" = true ]; then
+  dmg_path="out/make/dmg/darwin/${arch}/LyricSheet-darwin-${arch}-${version}.dmg"
+  dmg_name="$(basename "$dmg_path")"
+  dmg_checksum_path="$dmg_path.sha256"
+  [ -f "$dmg_path" ] || fail "packaged DMG not found at $dmg_path"
+
+  digest="$(shasum -a 256 "$dmg_path" | awk '{print $1}')"
+  printf '%s  %s\n' "$digest" "$dmg_name" > "$dmg_checksum_path"
+  printf 'dmg_path=%s\ndmg_checksum_path=%s\n' \
+    "$dmg_path" "$dmg_checksum_path"
+fi

--- a/Scripts/tests/ci-workflow-contract.sh
+++ b/Scripts/tests/ci-workflow-contract.sh
@@ -8,6 +8,8 @@ release_workflow="$root/.github/workflows/release.yml"
 consumer="$root/.github/tart-runner-consumer.tsv"
 actionlint_config="$root/.github/actionlint.yaml"
 toolchain_action="$root/.github/actions/setup-macos-node/action.yml"
+dmg_packager="$root/Scripts/package-macos-dmg.sh"
+dmg_verifier="$root/Scripts/verify-macos-dmg.sh"
 expected_consumer=$'tart-runner-consumer-v1\tlastfm-lyricsheet\tshaunchurch/lastfm-lyricsheet\tlastfm-lyricsheet-ci-tart-\tself-hosted,macOS,ARM64,tart-isolated,lastfm-lyricsheet'
 runner_labels='runs-on: [self-hosted, macOS, ARM64, tart-isolated, lastfm-lyricsheet]'
 
@@ -27,6 +29,8 @@ require_literal() {
 [ -f "$consumer" ] || fail "Tart consumer declaration is missing"
 [ -f "$actionlint_config" ] || fail "actionlint configuration is missing"
 [ -f "$toolchain_action" ] || fail "shared toolchain action is missing"
+[ -f "$dmg_packager" ] || fail "DMG packaging script is missing"
+[ -f "$dmg_verifier" ] || fail "DMG verification script is missing"
 
 [ "$(cat "$consumer")" = "$expected_consumer" ] ||
   fail "Tart consumer declaration does not match the controller contract"
@@ -65,7 +69,12 @@ done
 for value in \
   'APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}' \
   'MACOS_SIGN_IDENTITY=$SIGNING_IDENTITY_HASH' \
+  'bash Scripts/package-macos-dmg.sh' \
+  'bash Scripts/verify-macos-dmg.sh' \
   'bash Scripts/prepare-macos-artifacts.sh' \
+  '--with-dmg' \
+  '${{ steps.release_artifacts.outputs.dmg_path }}' \
+  '${{ steps.release_artifacts.outputs.dmg_checksum_path }}' \
   'actions/upload-artifact@v4' \
   'Stage draft release' \
   'Source commit: $GITHUB_SHA' \

--- a/Scripts/verify-macos-dmg.sh
+++ b/Scripts/verify-macos-dmg.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: verify-macos-dmg.sh --dmg <path> --version <x.y.z> --arch <arm64|x64|universal> --team-id <id>
+
+Checks the disk image's integrity, Developer ID signature, Gatekeeper
+acceptance, stapled notarization ticket, layout, and contained app.
+USAGE
+}
+
+dmg_path=""
+version=""
+arch=""
+team_id=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dmg)
+      dmg_path="${2:-}"
+      shift 2
+      ;;
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --arch)
+      arch="${2:-}"
+      shift 2
+      ;;
+    --team-id)
+      team_id="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -f "$dmg_path" ] || fail "DMG not found at $dmg_path"
+[ -n "$version" ] || fail "--version is required"
+case "$arch" in
+  arm64|x64|universal) ;;
+  *) fail "--arch must be arm64, x64, or universal" ;;
+esac
+[[ "$team_id" =~ ^[A-Z0-9]{10}$ ]] ||
+  fail "--team-id must be a 10-character Apple team ID"
+
+base_temp="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+base_temp="${base_temp%/}"
+workdir="$(mktemp -d "$base_temp/lyricsheet-dmg-verify.XXXXXX")"
+mountpoint="$workdir/mounted"
+details="$workdir/codesign-details.txt"
+mounted=false
+
+cleanup() {
+  if [ "$mounted" = true ]; then
+    if ! hdiutil detach "$mountpoint" -quiet 2>/dev/null; then
+      echo "could not detach verification mount: $mountpoint" >&2
+      return 1
+    fi
+    mounted=false
+  fi
+  case "$workdir" in
+    "$base_temp"/lyricsheet-dmg-verify.*)
+      find -x "$workdir" -depth -delete
+      ;;
+    *)
+      echo "refusing unexpected verification cleanup path: $workdir" >&2
+      return 1
+      ;;
+  esac
+}
+trap cleanup EXIT
+
+hdiutil verify "$dmg_path" >/dev/null
+codesign -dv --verbose=4 "$dmg_path" > "$details" 2>&1
+grep -q '^Authority=Developer ID Application:' "$details" ||
+  fail "DMG is not signed with a Developer ID Application certificate"
+grep -Fq "TeamIdentifier=$team_id" "$details" ||
+  fail "DMG is not signed by team $team_id"
+codesign --verify --strict --verbose=2 "$dmg_path"
+spctl -a -t open -vvv --context context:primary-signature "$dmg_path"
+xcrun stapler validate "$dmg_path"
+
+mkdir "$mountpoint"
+hdiutil attach "$dmg_path" \
+  -nobrowse \
+  -readonly \
+  -mountpoint "$mountpoint" \
+  -quiet
+mounted=true
+
+[ -L "$mountpoint/Applications" ] ||
+  fail "DMG is missing its Applications link"
+[ "$(readlink "$mountpoint/Applications")" = /Applications ] ||
+  fail "DMG Applications link has an unexpected target"
+
+app_path="$mountpoint/LyricSheet.app"
+"$(dirname "$0")/verify-macos-bundle.sh" \
+  --app "$app_path" \
+  --version "$version" \
+  --arch "$arch" \
+  --notarized \
+  --team-id "$team_id"
+
+hdiutil detach "$mountpoint" -quiet
+mounted=false
+
+echo "Verified signed and notarized LyricSheet DMG at $dmg_path"

--- a/Scripts/verify-published-release.sh
+++ b/Scripts/verify-published-release.sh
@@ -10,8 +10,8 @@ usage() {
   cat <<'USAGE'
 Usage: verify-published-release.sh --version <x.y.z> --release-repo <owner/repo> --tag <vX.Y.Z> --team-id <id> [--arch arm64|x64|universal]
 
-Downloads the public GitHub release zip and verifies that Gatekeeper can accept
-the shipped macOS app.
+Downloads the public GitHub release ZIP and DMG, checks both digests, and
+verifies that Gatekeeper accepts the shipped app and disk image.
 USAGE
 }
 
@@ -68,12 +68,18 @@ base_temp="${base_temp%/}"
 workdir="$(mktemp -d "$base_temp/lyricsheet-published-release.XXXXXX")"
 trap 'rm -rf "$workdir"' EXIT
 
-asset_name="LyricSheet-darwin-${arch}-${version}.zip"
-zip_url="https://github.com/${release_repo}/releases/download/${tag}/${asset_name}"
-zip_path="$workdir/$asset_name"
-checksum_name="$asset_name.sha256"
-checksum_url="$zip_url.sha256"
-checksum_path="$workdir/$checksum_name"
+zip_name="LyricSheet-darwin-${arch}-${version}.zip"
+zip_url="https://github.com/${release_repo}/releases/download/${tag}/${zip_name}"
+zip_path="$workdir/$zip_name"
+zip_checksum_name="$zip_name.sha256"
+zip_checksum_url="$zip_url.sha256"
+zip_checksum_path="$workdir/$zip_checksum_name"
+dmg_name="LyricSheet-darwin-${arch}-${version}.dmg"
+dmg_url="https://github.com/${release_repo}/releases/download/${tag}/${dmg_name}"
+dmg_path="$workdir/$dmg_name"
+dmg_checksum_name="$dmg_name.sha256"
+dmg_checksum_url="$dmg_url.sha256"
+dmg_checksum_path="$workdir/$dmg_checksum_name"
 unzipped_dir="$workdir/unzipped"
 app_path="$unzipped_dir/LyricSheet.app"
 
@@ -99,14 +105,25 @@ if [ -n "${GH_TOKEN:-}" ]; then
   gh release download "$tag" \
     --repo "$release_repo" \
     --dir "$workdir" \
-    --pattern "$asset_name" \
-    --pattern "$checksum_name" || fail "could not download staged release assets"
+    --pattern "$zip_name" \
+    --pattern "$zip_checksum_name" \
+    --pattern "$dmg_name" \
+    --pattern "$dmg_checksum_name" ||
+    fail "could not download staged release assets"
 else
-  echo "Downloading published release asset: $zip_url"
+  echo "Downloading published release assets for $tag"
   curl_retry "$zip_url" "$zip_path" || fail "could not download published release asset"
-  curl_retry "$checksum_url" "$checksum_path" || fail "could not download published checksum"
+  curl_retry "$zip_checksum_url" "$zip_checksum_path" ||
+    fail "could not download published ZIP checksum"
+  curl_retry "$dmg_url" "$dmg_path" ||
+    fail "could not download published DMG"
+  curl_retry "$dmg_checksum_url" "$dmg_checksum_path" ||
+    fail "could not download published DMG checksum"
 fi
-(cd "$workdir" && shasum -a 256 -c "$checksum_name") || fail "published checksum does not match"
+(cd "$workdir" && shasum -a 256 -c "$zip_checksum_name") ||
+  fail "published ZIP checksum does not match"
+(cd "$workdir" && shasum -a 256 -c "$dmg_checksum_name") ||
+  fail "published DMG checksum does not match"
 
 mkdir -p "$unzipped_dir"
 ditto -x -k "$zip_path" "$unzipped_dir"
@@ -119,4 +136,10 @@ ditto -x -k "$zip_path" "$unzipped_dir"
   --notarized \
   --team-id "$team_id"
 
-echo "Release $tag is signed, notarized, stapled, and Gatekeeper-accepted"
+"$(dirname "$0")/verify-macos-dmg.sh" \
+  --dmg "$dmg_path" \
+  --version "$version" \
+  --arch "$arch" \
+  --team-id "$team_id"
+
+echo "Release $tag ZIP and DMG are signed, notarized, stapled, and Gatekeeper-accepted"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -2,8 +2,8 @@
 
 LyricSheet macOS releases are distributed outside the Mac App Store. Release
 artifacts must be Developer ID signed, hardened-runtime enabled, notarized, and
-stapled before publishing. Unsigned local ZIPs can be rejected by Gatekeeper as
-damaged or corrupt after download.
+stapled before publishing. The DMG is the normal installer; the ZIP remains
+available for update tooling and manual installation.
 
 ## How to Ship
 
@@ -12,8 +12,8 @@ damaged or corrupt after download.
 3. Push a matching tag:
 
    ```sh
-   git tag v0.2.2
-   git push origin v0.2.2
+   git tag v0.2.3
+   git push origin v0.2.3
    ```
 
 4. Watch the **Release** GitHub Actions workflow.
@@ -31,15 +31,17 @@ damaged or corrupt after download.
    an ephemeral keychain.
 6. Builds LyricSheet with Electron Forge, Developer ID signing, hardened runtime,
    notarization, and stapling enabled.
-7. Packages `LyricSheet.app` with `ditto --keepParent`, writes a SHA-256 file,
-   and retains both as a workflow artifact.
-8. Stages a draft GitHub release tied to the source commit. Published releases
+7. Packages `LyricSheet.app` as a ZIP and DMG, signs and notarizes the outer
+   DMG, staples its ticket, and writes SHA-256 files for both artifacts.
+8. Verifies the local DMG's integrity, Developer ID team, Gatekeeper acceptance,
+   stapled ticket, Applications link, and contained app.
+9. Stages a draft GitHub release tied to the source commit. Published releases
    are immutable; only a draft owned by the same commit may be replaced.
-9. Downloads the staged artifacts and verifies the checksum, shipped app
-   version, bundle ID, architecture, expected signing team, hardened runtime,
-   code-signing integrity, Gatekeeper acceptance, and notarization ticket.
-10. Publishes the draft only after verification passes.
-11. Removes the release keychain and API key material on every exit path. The
+10. Downloads both staged artifacts and verifies their checksums, shipped app
+    version, bundle ID, architecture, expected signing team, hardened runtime,
+    code-signing integrity, Gatekeeper acceptance, and notarization tickets.
+11. Publishes the draft only after verification passes.
+12. Removes the release keychain and API key material on every exit path. The
     Tart controller then erases the VM.
 
 Sparkle updates are intentionally out of scope for now.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastfm-lyricsheet",
   "productName": "LyricSheet",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A tiny always-on desktop lyric sheet for your current Last.fm track.",
   "main": ".vite/build/main.js",
   "private": true,


### PR DESCRIPTION
## What changed

- bump LyricSheet to 0.2.3
- build a standard Finder DMG alongside the existing ZIP
- Developer ID sign, separately notarize, staple, and Gatekeeper-check the outer DMG
- verify the mounted DMG layout and the signed app inside it
- checksum, stage, re-download, and verify all four release assets before publication

## Why

The 0.2.2 release only shipped a ZIP. A DMG provides the normal macOS installation experience while the ZIP remains available for update tooling and manual installation.

## Release impact

After this PR merges and `v0.2.3` is tagged, the immutable release will contain the ZIP, DMG, and SHA-256 files for both. The release remains draft until every local and staged verification gate passes.

## Checks

- `pnpm run typecheck`
- `pnpm test` (6 passing)
- workflow contract, actionlint, ShellCheck, and diff check
- local unsigned 0.2.3 ZIP and DMG packaging
- ZIP and DMG SHA-256 verification
- DMG filesystem/mount layout and contained 0.2.3 app verification
- expected rejection of the unsigned fixture by the signed-DMG verifier
- standards review: no findings
- spec review: no findings